### PR TITLE
Support validation of example/examples in request

### DIFF
--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -9,6 +9,10 @@ const { JSONPath: jsonPath } = require('jsonpath-plus'),
 
 const PATH__EXAMPLE = '$..responses..content.application/json.example',
     PATH__EXAMPLES = '$..responses..content.application/json.examples..value',
+    PATH__EXAMPLE__PARAMETER = '$..parameters..example',
+    PATH__EXAMPLES__PARAMETER = '$..parameters..examples..value',
+    PATH__EXAMPLE__REQUEST_BODY = '$..requestBody.content.application/json.example',
+    PATH__EXAMPLES__REQUEST_BODY = '$..requestBody.content.application/json.examples..value',
     PROP__SCHEMA = 'schema',
     PROP__EXAMPLE = 'example',
     PROP__EXAMPLES = 'examples';
@@ -31,7 +35,16 @@ module.exports = {
  * Get the JSONPaths to the examples
  * @returns {Array.<String>}    JSONPaths to the examples
  */
-function getJsonPathsToExamples() { return [PATH__EXAMPLE, PATH__EXAMPLES]; }
+function getJsonPathsToExamples() {
+    return [
+        PATH__EXAMPLE,
+        PATH__EXAMPLES,
+        PATH__EXAMPLE__PARAMETER,
+        PATH__EXAMPLES__PARAMETER,
+        PATH__EXAMPLE__REQUEST_BODY,
+        PATH__EXAMPLES__REQUEST_BODY
+    ];
+}
 
 /**
  * Builds a map with the path to the repsonse-schema as key and the paths to the examples, as value. The path of the

--- a/test/data/v3/request-invalid-parameter-examples.json
+++ b/test/data/v3/request-invalid-parameter-examples.json
@@ -1,0 +1,180 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "number"
+            },
+            "examples": {
+              "id1": {
+                "summary": "One invalid ID",
+                "value": "Lassie"
+              },
+              "id2": {
+                "summary": "One invalid ID",
+                "value": "Rex"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-invalid-parameter.json
+++ b/test/data/v3/request-invalid-parameter.json
@@ -1,0 +1,171 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "number"
+            },
+            "example": "Lassie"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-invalid-requestbody-examples.json
+++ b/test/data/v3/request-invalid-requestbody-examples.json
@@ -1,0 +1,184 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "default": {
+                  "summary": "Standard example",
+                  "value": {
+                    "name": 5,
+                    "tag": "Doggo"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "id": 0,
+                  "name": "Herbert",
+                  "tag": "Doggo"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-invalid-requestbody.json
+++ b/test/data/v3/request-invalid-requestbody.json
@@ -1,0 +1,179 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              },
+              "example": {
+                "name": 5,
+                "tag": "Doggo"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "id": 0,
+                  "name": "Herbert",
+                  "tag": "Doggo"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-valid-parameter-examples.json
+++ b/test/data/v3/request-valid-parameter-examples.json
@@ -1,0 +1,176 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "number"
+            },
+            "examples": {
+              "default": {
+                "summary": "Standard example",
+                "value": 5
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-valid-parameter.json
+++ b/test/data/v3/request-valid-parameter.json
@@ -1,0 +1,171 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "number"
+            },
+            "example": 5
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-valid-requestbody-examples.json
+++ b/test/data/v3/request-valid-requestbody-examples.json
@@ -1,0 +1,184 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              },
+              "examples": {
+                "default": {
+                  "summary": "Standard example",
+                  "value": {
+                    "name": "Herbert",
+                    "tag": "Doggo"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "id": 0,
+                  "name": "Herbert",
+                  "tag": "Doggo"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/data/v3/request-valid-requestbody.json
+++ b/test/data/v3/request-valid-requestbody.json
@@ -1,0 +1,179 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "requestBody": {
+          "description": "Pet data",
+          "content": {
+            "application/json": {
+              "schema": {
+                "required": [
+                  "name",
+                  "tag"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the pet",
+                    "type": "string"
+                  },
+                  "tag": {
+                    "description": "Category of pet",
+                    "type": "string"
+                  }
+                }
+              },
+              "example": {
+                "name": "Herbert",
+                "tag": "Doggo"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "id",
+                    "name",
+                    "tag"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique ID",
+                      "type": "number"
+                    },
+                    "name": {
+                      "description": "Name of the pet",
+                      "type": "string"
+                    },
+                    "tag": {
+                      "description": "Category of pet",
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "id": 0,
+                  "name": "Herbert",
+                  "tag": "Doggo"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/specs/impl/v3/index.js
+++ b/test/specs/impl/v3/index.js
@@ -12,6 +12,18 @@ const JSON_PATH__CONTEXT_MUTUALLY_EXCLUSIVE = '/paths/~1pets/get/responses/200/c
     REL_PATH__EXAMPLES__INVALID__WITH_INTERNAL_REFS = 'v3/simple-api-with-examples-with-refs-invalid',
     FILE_PATH__INVALID__YAML = path.join(__dirname, '../../../data/v3/simple-api-with-examples-with-refs-invalid.yaml'),
     FILE_PATH__INVALID__YML = path.join(__dirname, '../../../data/v3/simple-api-with-examples-with-refs-invalid.yml'),
+    FILE_PATH__VALID__REQUEST_PARAMETER = path.join(__dirname, '../../../data/v3/request-valid-parameter.json'),
+    FILE_PATH__VALID__REQUEST_PARAMETER__EXAMPLES
+        = path.join(__dirname, '../../../data/v3/request-valid-parameter-examples.json'),
+    FILE_PATH__INVALID__REQUEST_PARAMETER = path.join(__dirname, '../../../data/v3/request-invalid-parameter.json'),
+    FILE_PATH__INVALID__REQUEST_PARAMETER__EXAMPLES
+        = path.join(__dirname, '../../../data/v3/request-invalid-parameter-examples.json'),
+    FILE_PATH__VALID__REQUEST_BODY = path.join(__dirname, '../../../data/v3/request-valid-requestbody.json'),
+    FILE_PATH__VALID__REQUEST_BODY__EXAMPLES
+        = path.join(__dirname, '../../../data/v3/request-valid-requestbody-examples.json'),
+    FILE_PATH__INVALID__REQUEST_BODY = path.join(__dirname, '../../../data/v3/request-invalid-requestbody.json'),
+    FILE_PATH__INVALID__REQUEST_BODY__EXAMPLES
+        = path.join(__dirname, '../../../data/v3/request-invalid-requestbody-examples.json'),
     FILE_PATH__VALID__YAML = path.join(__dirname, '../../../data/v3/simple-api-with-examples-with-refs.yaml'),
     FILE_PATH__VALID__YML = path.join(__dirname, '../../../data/v3/simple-api-with-examples-with-refs.yml');
 
@@ -63,6 +75,42 @@ describe('Main-module, for v3 should', function() {
             });
             it('`with .yml` extension', function() {
                 validateFile(FILE_PATH__INVALID__YML).valid.should.equal(false);
+            });
+        });
+    });
+    describe('be able to validate request parameters', function() {
+        describe('in example-property', function() {
+            it('with a valid example', function() {
+                validateFile(FILE_PATH__VALID__REQUEST_PARAMETER).valid.should.equal(true);
+            });
+            it('with an invalid example', function() {
+                validateFile(FILE_PATH__INVALID__REQUEST_PARAMETER).valid.should.equal(false);
+            });
+        });
+        describe('in examples-property', function() {
+            it('with a valid example', function() {
+                validateFile(FILE_PATH__VALID__REQUEST_PARAMETER__EXAMPLES).valid.should.equal(true);
+            });
+            it('with an invalid example', function() {
+                validateFile(FILE_PATH__INVALID__REQUEST_PARAMETER__EXAMPLES).valid.should.equal(false);
+            });
+        });
+    });
+    describe('be able to validate request-bodies', function() {
+        describe('in example-property', function() {
+            it('with a valid example', function() {
+                validateFile(FILE_PATH__VALID__REQUEST_BODY).valid.should.equal(true);
+            });
+            it('with an invalid example', function() {
+                validateFile(FILE_PATH__INVALID__REQUEST_BODY).valid.should.equal(false);
+            });
+        });
+        describe('in examples-property', function() {
+            it('with a valid example', function() {
+                validateFile(FILE_PATH__VALID__REQUEST_BODY__EXAMPLES).valid.should.equal(true);
+            });
+            it('with an invalid example', function() {
+                validateFile(FILE_PATH__INVALID__REQUEST_BODY__EXAMPLES).valid.should.equal(false);
             });
         });
     });


### PR DESCRIPTION
as `parameters` and `requestBody`

Closes #29 