### PR TITLE
fix: don't recognize `value`-properties as examples

### DIFF
--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -8,11 +8,11 @@ const { JSONPath: jsonPath } = require('jsonpath-plus'),
 // CONSTANTS
 
 const PATH__EXAMPLE = '$..responses..content.application/json.example',
-    PATH__EXAMPLES = '$..responses..content.application/json.examples..value',
+    PATH__EXAMPLES = '$..responses..content.application/json.examples.*.value',
     PATH__EXAMPLE__PARAMETER = '$..parameters..example',
-    PATH__EXAMPLES__PARAMETER = '$..parameters..examples..value',
+    PATH__EXAMPLES__PARAMETER = '$..parameters..examples.*.value',
     PATH__EXAMPLE__REQUEST_BODY = '$..requestBody.content.application/json.example',
-    PATH__EXAMPLES__REQUEST_BODY = '$..requestBody.content.application/json.examples..value',
+    PATH__EXAMPLES__REQUEST_BODY = '$..requestBody.content.application/json.examples.*.value',
     PROP__SCHEMA = 'schema',
     PROP__EXAMPLE = 'example',
     PROP__EXAMPLES = 'examples';

--- a/test/data/v3/valid-single-with-value-property.yaml
+++ b/test/data/v3/valid-single-with-value-property.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: 'http://petstore.swagger.io/v1'
+paths:
+  /pets:
+    get:
+      summary: List all assets
+      operationId: listAssets
+      responses:
+        '200':
+          description: An array of assets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Assets'
+              examples:
+                single:
+                  summary: a single example
+                  value:
+                    value:
+                      - id: 0
+                        name: Table
+                        tag: furniture
+                        value: 500
+                        currency: USD
+components:
+  schemas:
+    Asset:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: number
+        name:
+          type: string
+        tag:
+          type: string
+        value:
+            type: number
+    Assets:
+      type: object
+      properties:
+        value:
+          type: array
+          items:
+            $ref: '#/components/schemas/Asset'

--- a/test/specs/impl/v3/index.js
+++ b/test/specs/impl/v3/index.js
@@ -34,6 +34,7 @@ const JSON_PATH__CONTEXT_MUTUALLY_EXCLUSIVE = '/paths/~1pets/get/responses/200/c
     FILE_PATH__INVALID__REQUEST_BODY = path.join(__dirname, '../../../data/v3/request-invalid-requestbody.json'),
     FILE_PATH__INVALID__REQUEST_BODY__EXAMPLES
         = path.join(__dirname, '../../../data/v3/request-invalid-requestbody-examples.json'),
+    FILE_PATH__VALID__VALUE_PROPERTY = path.join(__dirname, '../../../data/v3/valid-single-with-value-property.yaml'),
     FILE_PATH__VALID__YAML = path.join(__dirname, '../../../data/v3/simple-api-with-examples-with-refs.yaml'),
     FILE_PATH__VALID__YML = path.join(__dirname, '../../../data/v3/simple-api-with-examples-with-refs.yml');
 
@@ -236,6 +237,17 @@ describe('Main-module, for v3 should', function() {
                 error.message.should.equal('should match format "double"');
                 error.keyword.should.equal('format');
                 error.params.format.should.equal('double');
+            });
+        });
+    });
+    describe('example with `value`s as properties', function() {
+        it('should not be recognized as separate example', async function() {
+            const { valid, statistics } = (await validateFile(FILE_PATH__VALID__VALUE_PROPERTY));
+            valid.should.equal(true);
+            statistics.should.deep.equal({
+                schemasWithExamples: 1,
+                examplesWithoutSchema: 0,
+                examplesTotal: 1
             });
         });
     });


### PR DESCRIPTION
closes #80 

Don't recognize every `value`-property as an example.