### PR TITLE
fix: detect examples with names that have to be escaped

### DIFF
--- a/src/impl/v2/index.js
+++ b/src/impl/v2/index.js
@@ -14,8 +14,10 @@ const PATH__EXAMPLES = '$..examples.application/json',
 
 module.exports = {
     buildValidationMap,
+    escapeExampleName,
     getJsonPathsToExamples,
-    prepare
+    prepare,
+    unescapeExampleNames
 };
 
 // IMPLEMENTATION DETAILS
@@ -54,6 +56,27 @@ function prepare(openapiSpec, { noAdditionalProperties } = {}) {
     const openapiSpecCopy = cloneDeep(openapiSpec);
     noAdditionalProperties && setNoAdditionalProperties(openapiSpecCopy, getJsonPathsToExamples());
     return openapiSpecCopy;
+}
+
+/**
+ * Escapes the name of the example.
+ * @param {string} rawPath  Unescaped path
+ * @returns {string} Escaped path
+ * @private
+ */
+function escapeExampleName(rawPath) {
+    // No escaping necessary in v2, as there are no named-examples
+    return rawPath;
+}
+
+/**
+ * Escaped example-names reflect in the result (where they shouldn't). This function reverts it.
+ * @param {string} rawPath  Escaped path
+ * @returns {string} Unescaped path
+ */
+function unescapeExampleNames(rawPath) {
+    // No unescaping necessary in v2, as there are no named-examples
+    return rawPath;
 }
 
 /**

--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -28,8 +28,10 @@ const ExampleType = {
 
 module.exports = {
     buildValidationMap,
+    escapeExampleName,
     getJsonPathsToExamples,
-    prepare
+    prepare,
+    unescapeExampleNames
 };
 
 // IMPLEMENTATION DETAILS
@@ -83,6 +85,25 @@ function prepare(openapiSpec, { noAdditionalProperties } = {}) {
     const openapiSpecCopy = cloneDeep(openapiSpec);
     noAdditionalProperties && setNoAdditionalProperties(openapiSpecCopy, getJsonPathsToExamples());
     return openapiSpecCopy;
+}
+
+/**
+ * Escapes the name of the example. In order to do that, a backtick has to be added to the beginning of the key.
+ * @param {string} rawPath  Unescaped path
+ * @returns {string} Escaped path
+ * @private
+ */
+function escapeExampleName(rawPath) {
+    return rawPath.replace(/\['examples'\]\['(.*)\]\['value'\]$/, "['examples']['`$1]['value']");
+}
+
+/**
+ * Escaped example-names reflect in the result (where they shouldn't). This function reverts it.
+ * @param {string} rawPath  Escaped path
+ * @returns {string} Unescaped path
+ */
+function unescapeExampleNames(rawPath) {
+    return rawPath && rawPath.replace(/\/examples\/`(.*)\/value$/, '/examples/$1/value');
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ async function validateExamples(openapiSpec, { noAdditionalProperties } = {}) {
     let pathsExamples = impl.getJsonPathsToExamples()
         .reduce((res, pathToExamples) => {
             return res.concat(_extractExamplePaths(openapiSpec, pathToExamples));
-        }, []);
+        }, [])
+        .map(impl.escapeExampleName);
     return _validateExamplesPaths({ impl }, pathsExamples, openapiSpec);
 }
 
@@ -404,6 +405,10 @@ function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec) {
             openapiSpec, createValidator, pathSchema, validationMap, statistics,
             validationResult
         });
+    });
+    // Revert escaped example names from the results
+    validationResult.errors.forEach((example) => {
+        example.examplePath = impl.unescapeExampleNames(example.examplePath);
     });
     return validationResult;
 }

--- a/test/data/v3/errors/simple-api-with-example-names-to-be-escaped.json
+++ b/test/data/v3/errors/simple-api-with-example-names-to-be-escaped.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "Validation",
+    "message": "should be number",
+    "keyword": "type",
+    "dataPath": "[0].id",
+    "schemaPath": "#/items/properties/id/type",
+    "params": {
+      "type": "number"
+    },
+    "examplePath": "/paths/~1pets/get/responses/200/content/application~1json/examples/`mrcat/value"
+  },
+  {
+    "type": "Validation",
+    "message": "should be number",
+    "keyword": "type",
+    "dataPath": "[0].id",
+    "schemaPath": "#/items/properties/id/type",
+    "params": {
+      "type": "number"
+    },
+    "examplePath": "/paths/~1pets/get/responses/200/content/application~1json/examples/herbert,doggo/value"
+  }
+]

--- a/test/data/v3/simple-api-with-example-names-to-be-escaped.json
+++ b/test/data/v3/simple-api-with-example-names-to-be-escaped.json
@@ -1,0 +1,115 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v1"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "required": [
+                      "id",
+                      "name"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "number"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "herbert,doggo": {
+                    "value": [
+                      {
+                        "id": "invalid-id",
+                        "name": "Herbert",
+                        "tag": "Doggo"
+                      }
+                    ]
+                  },
+                  "`mrcat": {
+                    "value": [
+                      {
+                        "id": "invalid-id",
+                        "name": "`mrcat",
+                        "tag": "Kitty"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "required": [
+                    "code",
+                    "message"
+                  ],
+                  "properties": {
+                    "code": {
+                      "type": "number"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/specs/impl/v3/index.js
+++ b/test/specs/impl/v3/index.js
@@ -14,7 +14,9 @@ const path = require('path'),
     errorsAdditionalPropertiesSingle
         = require('../../../data/v3/additional-properties/errors-single.json'),
     errorsExclusiveMinimum
-        = require('../../../data/v3/draft-04-properties/errors-exclusive-minimum.json');
+        = require('../../../data/v3/draft-04-properties/errors-exclusive-minimum.json'),
+    errorsEscapedErrorNames
+        = require('../../../data/v3/errors/simple-api-with-example-names-to-be-escaped.json');
 
 const JSON_PATH__CONTEXT_MUTUALLY_EXCLUSIVE = '/paths/~1pets/get/responses/200/content/application~1json',
     REL_PATH__EXAMPLE__SIMPLE = 'v3/simple-api-with-example',
@@ -64,7 +66,9 @@ const JSON_PATH__CONTEXT_MUTUALLY_EXCLUSIVE = '/paths/~1pets/get/responses/200/c
     FILE_PATH__VALID_EXAMPLES_EXCLUSIVE_MINIMUM
         = path.join(__dirname, '../../../data/v3/simple-api-with-examples-exclusive-minimum.json'),
     FILE_PATH__INVALID_EXAMPLES_EXCLUSIVE_MINIMUM
-        = path.join(__dirname, '../../../data/v3/simple-api-with-examples-exclusive-minimum-invalid.json');
+        = path.join(__dirname, '../../../data/v3/simple-api-with-examples-exclusive-minimum-invalid.json'),
+    FILE_PATH__EXAMPLE_NAMES_TO_BE_ESCAPED
+        = path.join(__dirname, '../../../data/v3/simple-api-with-example-names-to-be-escaped.json');
 
 describe('Main-module, for v3 should', function() {
     describe('recognize', function() {
@@ -364,6 +368,12 @@ describe('Main-module, for v3 should', function() {
         it('`validateFile` should throw an error', async function() {
             (await validateFile(FILE_PATH__INVALID_EXAMPLES_EXCLUSIVE_MINIMUM))
                 .errors.should.deep.equal(errorsExclusiveMinimum);
+        });
+    });
+    describe('escape example names, to make sure they can be selected by JSONpath', function() {
+        it('`validateFile` should throw an error', async function() {
+            (await validateFile(FILE_PATH__EXAMPLE_NAMES_TO_BE_ESCAPED))
+                .errors.should.deep.equal(errorsEscapedErrorNames);
         });
     });
 });


### PR DESCRIPTION
Closes #125 