### PR TITLE
fix: log warning for all combiners, not only `allOf`, if `additionalProperties`-flag is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Caveat
 - The formats `int32`, `float` and `double` are supported for the type `number`. The format `int64` is only available
   for the type `string`, though (due to the precision-limitations of Javascript).
 - The option `--no-additional-properties` does not work, if `allOf` is used to combine subschemas.
-  - Enabling this flag will not be apply `additionalProperties` to any subschemas that use the
-    [`allOf`](https://json-schema.org/understanding-json-schema/reference/combining.html) combiner keyword.
+  - Enabling this flag will not apply `additionalProperties` to any subschemas that use
+    [these](https://json-schema.org/understanding-json-schema/reference/combining.html) combiner keywords.
   - A warning will be logged if setting the `additionalProperties` flag has been skipped.
 
 Test

--- a/src/impl/service/disallow-additional-properties.js
+++ b/src/impl/service/disallow-additional-properties.js
@@ -6,7 +6,12 @@ const JSON_PATHS__OBJECTS = [
     '$..schema..[?(@.properties && (@property === "schema" || @property === "items" || @.type === "object"))]'
 ];
 
-const COMBINER__ALL_OF = 'allOf';
+const JSON_SCHEMA_COMBINERS = [
+    'oneOf',
+    'allOf',
+    'anyOf',
+    'not'
+];
 
 module.exports = {
     setNoAdditionalProperties
@@ -46,12 +51,12 @@ function setNoAdditionalProperties(openApiSpec, examplePaths = [],
     JSON_PATHS__OBJECTS.forEach(jsPath => {
         _find(openApiSpec, jsPath)
             .forEach(match => {
-                // remove all references to paths including the `allOf`-combiner
-                if (!match.includes(`['${COMBINER__ALL_OF}']`)) {
+                // remove all references to paths including any of the JSON schema combiners
+                if (!JSON_SCHEMA_COMBINERS.some((combiner) => match.includes(`['${combiner}']`))) {
                     paths.add(match);
                 } else {
                     console.warn('"additionalProperties" flag not set '
-                        + `for ${match} because it contains the "allOf" combiner keyword.`);
+                        + `for ${match} because it contains JSON-schema combiner keywords.`);
                 }
             });
     });
@@ -70,12 +75,12 @@ function setNoAdditionalProperties(openApiSpec, examplePaths = [],
  */
 function _callbackObjectTypeForNoAdditionalProperties(value) {
     const asString = JSON.stringify(value);
-    // any schema's that use the `allOf`-combiner should also be excluded
-    if (!asString.includes(`"${COMBINER__ALL_OF}"`)) {
+    // any schema's that use JSON schema combiners should also be excluded
+    if (!JSON_SCHEMA_COMBINERS.some((combiner) => asString.includes(`"${combiner}"`))) {
         value.additionalProperties = false;
     } else {
         console.warn('"additionalProperties" flag not set'
-            + `for ${asString} because it contains the "allOf" combiner keyword.`);
+            + `for ${asString} because it contains JSON-schema combiner keywords.`);
     }
 }
 

--- a/test/data/v3/additional-properties/schema-with-schema-combiner-invalid.yaml
+++ b/test/data/v3/additional-properties/schema-with-schema-combiner-invalid.yaml
@@ -25,6 +25,7 @@ paths:
             application/json:
               schema:
                 oneOf:
+                  - $ref: '#/components/schemas/Bird'
                   - $ref: '#/components/schemas/Cat'
                   - $ref: '#/components/schemas/Dog'
               examples:
@@ -38,6 +39,10 @@ paths:
                     name: 'Cat 1'
                     hunts: true
                     age: 3
+                'Bird example':
+                  value:
+                    name: 'Birb'
+                    sizeWings: 'smol'
         '404':
           description: unexpected error
           content:
@@ -47,7 +52,7 @@ paths:
               example:
                 code: 1000
                 message: 'could not find pet'
-                extra_property: 'test' # not allowed and outside of `allOf` schema combiner, should be picked up
+                extra_property: 'test' # not allowed and outside of JSON schema combiner, should be picked up
 components:
   schemas:
     Error:
@@ -89,3 +94,23 @@ components:
               type: boolean
             age:
               type: integer
+    Bird:
+      anyOf:
+        - type: object
+          required:
+            - name
+            - sizeWings
+          properties:
+            name:
+              type: string
+            sizeWings:
+              type: string
+        - type: object
+          required:
+            - name
+            - eggSize
+          properties:
+            name:
+              type: string
+            sizeEggs:
+              type: string


### PR DESCRIPTION
Closes #132 