### PR TITLE
Fix tests on Windows platform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
     let responses = [];
     // for..of here, to support sequential execution of async calls. This is required, since dereferencing the
     // `openapiSpec` is not concurrency-safe
-    for (let filePathMapExternalExamples of filePathsMaps) {
+    for (const filePathMapExternalExamples of filePathsMaps) {
         let mapExternalExamples = null,
             openapiSpec = null;
         try {
@@ -170,7 +170,7 @@ async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
             responses.push(createValidationResponse({ errors: [ApplicationError.create(err)] }));
             continue;
         }
-        // Not using `glob`'s response-length, becuse it is `1` if there's no match for `globMapExternalExamples`.
+        // Not using `glob`'s response-length, because it is `1` if there's no match for `globMapExternalExamples`.
         // Instead, increment on every match
         matchingFilePathsMapping++;
         responses.push(
@@ -184,7 +184,7 @@ async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
                         }
                     ).map(
                         (/** @type ApplicationError */ error) => Object.assign(error, {
-                            mapFilePath: filePathMapExternalExamples
+                            mapFilePath: path.normalize(filePathMapExternalExamples)
                         })
                     );
                 }

--- a/test/specs/cli.js
+++ b/test/specs/cli.js
@@ -1,4 +1,5 @@
-const util = require('util'),
+const { platform } = require('os'),
+    util = require('util'),
     VERSION = require('../../package').version,
     { text: _textHelp } = require('../data/output-help'),
     { text: _textMapExternalExamples } = require('../data/v2/output-map-external-examples'),
@@ -17,6 +18,9 @@ describe('CLI-module', function() {
         // Make sure that `commander`'s output will be the same, independent of the console's width
         this.origColumns = process.stdout.columns;
         process.stdout.columns = 80;
+        if (platform() === 'win32') {
+            process.env.ComSpec = 'PowerShell.exe';
+        }
     });
     after(function() {
         process.stdout.columns = this.origColumns;


### PR DESCRIPTION
2 tests are failing when the library is executed on windows platform:

# Test 1
```
CLI-module
  spawning a child process
    ignore datatype formats
      should show no error when formats have been passed, with newline separated
```
## Issue
the default shell used to spawn child processes in windows is `cmd.exe` that does not support new line in the commands.
## Proposed solution
In case of platform Windows, set the default shell to PowerShell.exe

# Test 2
```
Main-module, for v3 should
with additional properties
with flag set
`validateExamplesByMap` should throw an error
```
## Issue
The function `glob.sync()` at `src\index.js:153` returns a different path format compared to `path.json()`.
In Windows platform, paths should use forward slashes, but `glob.sync()` returns paths with backslashes.
This discrepancy creates a difference between the expected path and the path in the error message.
## Proposed solution
Use the function `path.normalize()` to convert the path generated by `glob.sync()` to a valid Windows path.