### PR TITLE
Make type definitions available to TypeScript consumers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,13 @@
         "@babel/register": "^7.28.6",
         "@stryker-mutator/core": "^9.6.0",
         "@stryker-mutator/mocha-runner": "^9.6.0",
+        "@types/glob": "^8.1.0",
+        "@types/json-pointer": "^1.0.34",
+        "@types/lodash.clonedeep": "^4.5.9",
+        "@types/lodash.flatmap": "^4.5.9",
+        "@types/lodash.flatten": "^4.4.9",
+        "@types/lodash.merge": "^4.6.9",
+        "@types/node": "*",
         "babel-loader": "^10.1.1",
         "chai": "^4.5.0",
         "chai-string": "^1.6.0",
@@ -49,6 +56,7 @@
         "nyc": "^17.1.0",
         "rimraf": "^6.1.3",
         "standard-version": "^9.5.0",
+        "typescript": "^6.0.2",
         "webpack": "^5.105.4",
         "webpack-cli": "^6.0.1"
       },
@@ -3052,6 +3060,17 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -3076,10 +3095,71 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/json-pointer": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-pointer/-/json-pointer-1.0.34.tgz",
+      "integrity": "sha512-JRnWcxzXSaLei98xgw1B7vAeBVOrkyw0+Rt9j1QoJrczE78OpHsyQC8GNbuhw+/2vxxDe58QvWnngS86CoIbRg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.flatmap": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatmap/-/lodash.flatmap-4.5.9.tgz",
+      "integrity": "sha512-rACVyVCkf+YRthjL7wKb2e96nnZw+bRIEo2nl2ewP0GZLOuRP9QcB7FnyOj7aXI5Vrs6qONnc1lg66FdHVqCmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.flatten": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.9.tgz",
+      "integrity": "sha512-JCW9xofpn9oJfFSccpBRF8IrB5guqmcKZIa7J9DnZqLd9wgGYbewaYnjbNw3Fb+St8BHVsnGmmS0A3j99LII3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.merge": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
+      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimist": {
@@ -10434,6 +10514,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.17.4",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
@@ -13084,6 +13178,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "@types/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "^5.1.2",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -13108,10 +13212,64 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json-pointer": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@types/json-pointer/-/json-pointer-1.0.34.tgz",
+      "integrity": "sha512-JRnWcxzXSaLei98xgw1B7vAeBVOrkyw0+Rt9j1QoJrczE78OpHsyQC8GNbuhw+/2vxxDe58QvWnngS86CoIbRg==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
+      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.flatmap": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatmap/-/lodash.flatmap-4.5.9.tgz",
+      "integrity": "sha512-rACVyVCkf+YRthjL7wKb2e96nnZw+bRIEo2nl2ewP0GZLOuRP9QcB7FnyOj7aXI5Vrs6qONnc1lg66FdHVqCmQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.flatten": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.9.tgz",
+      "integrity": "sha512-JCW9xofpn9oJfFSccpBRF8IrB5guqmcKZIa7J9DnZqLd9wgGYbewaYnjbNw3Fb+St8BHVsnGmmS0A3j99LII3Q==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.merge": {
+      "version": "4.6.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.9.tgz",
+      "integrity": "sha512-23sHDPmzd59kUgWyKGiOMO2Qb9YtqRO/x4IhkgNUiPQ1+5MUVqi6bCZeq9nBJ17msjIMbEIO5u+XW4Kz6aGUhQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -18444,6 +18602,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.17.4",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.0.0",
   "description": "Validates embedded examples in OpenAPI-JSONs",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=20"
   },
@@ -16,9 +17,10 @@
   },
   "scripts": {
     "start-dev": "babel-node src/cli",
-    "build": "npm run build:clean && npm run build:webpack",
+    "build": "npm run build:clean && npm run build:webpack && npm run build:types",
     "build:clean": "rimraf dist",
     "build:webpack": "webpack --bail --progress --profile --mode production --config ./webpack/config.babel.js",
+    "build:types": "tsc -p tsconfig.json --noCheck",
     "coverage": "rimraf ./coverage && nyc --reporter=lcov --reporter=text -x \"dist/**/*\" -x \"test/**/*.js\" npm test",
     "test": "npm run build && npm run test:mocha",
     "test-mutations": "stryker run",
@@ -53,6 +55,13 @@
     "@babel/register": "^7.28.6",
     "@stryker-mutator/core": "^9.6.0",
     "@stryker-mutator/mocha-runner": "^9.6.0",
+    "@types/glob": "^8.1.0",
+    "@types/json-pointer": "^1.0.34",
+    "@types/lodash.clonedeep": "^4.5.9",
+    "@types/lodash.flatmap": "^4.5.9",
+    "@types/lodash.flatten": "^4.4.9",
+    "@types/lodash.merge": "^4.6.9",
+    "@types/node": "*",
     "babel-loader": "^10.1.1",
     "chai": "^4.5.0",
     "chai-string": "^1.6.0",
@@ -66,6 +75,7 @@
     "nyc": "^17.1.0",
     "rimraf": "^6.1.3",
     "standard-version": "^9.5.0",
+    "typescript": "^6.0.2",
     "webpack": "^5.105.4",
     "webpack-cli": "^6.0.1"
   },

--- a/src/application-error.js
+++ b/src/application-error.js
@@ -12,18 +12,18 @@ const
 /**
  * ApplicationErrorOptions
  * @typedef {{
- *      [instancePath]: string,
- *      [examplePath]: string,
- *      [exampleFilePath]: string,
- *      [keyword]: string,
- *      [message]: string,
- *      [mapFilePath]: string,
- *      [params]: {
- *          [path]: string,
- *          [missingProperty]: string,
- *          [type]: string
+ *      instancePath?: string,
+ *      examplePath?: string,
+ *      exampleFilePath?: string,
+ *      keyword?: string,
+ *      message?: string,
+ *      mapFilePath?: string,
+ *      params?: {
+ *          path?: string,
+ *          missingProperty?: string,
+ *          type?: string
  *      },
- *      [schemaPath]: string
+ *      schemaPath?: string
  * }} ApplicationErrorOptions
  */
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,6 +5,8 @@
  * Command Line Interface for the validator
  */
 
+/** @import { ValidationResponse, ValidationStatistics } from '.' */
+
 const
     VERSION = require('../package.json').version,
     program = require('commander'),
@@ -43,6 +45,17 @@ module.exports = program.parseAsync(process.argv);
 
 // IMPLEMENTATION DETAILS
 
+/**
+ * @param {string} filepath
+ * @param {Object} options
+ * @param {string} [options.schemaJsonpath]
+ * @param {string} [options.exampleFilepath]
+ * @param {string} [options.mappingFilepath]
+ * @param {boolean} [options.cwdToMappingFile]
+ * @param {boolean} [options.allPropertiesRequired]
+ * @param {boolean} [options.additionalProperties]
+ * @param {Array<string>} [options.ignoreFormats]
+ */
 async function processAction(filepath, options) {
     const { schemaJsonpath, exampleFilepath, mappingFilepath, cwdToMappingFile, allPropertiesRequired } = options,
         noAdditionalProperties = !options.additionalProperties,
@@ -74,6 +87,9 @@ async function processAction(filepath, options) {
     _handleResult(result);
 }
 
+/**
+ * @param {ValidationResponse} result
+ */
 function _handleResult(result) {
     const noExit = ENV_TEST;
     _printStatistics(result.statistics);
@@ -87,6 +103,9 @@ function _handleResult(result) {
     !noExit && process.exit(1);
 }
 
+/**
+ * @param {ValidationStatistics} statistics
+ */
 function _printStatistics(statistics) {
     const {
             schemasWithExamples,
@@ -105,6 +124,9 @@ function _printStatistics(statistics) {
     process.stdout.write(`${ strStatistics.join('\n') }\n`);
 }
 
+/**
+ * @param {Array<string> | undefined} ignoreFormats
+ */
 function _prepareIgnoreFormats(ignoreFormats) {
     if (ignoreFormats == null || !Array.isArray(ignoreFormats)) { return ignoreFormats; }
     if (ignoreFormats.length !== 1) { return ignoreFormats; }

--- a/src/const/result-type.js
+++ b/src/const/result-type.js
@@ -1,7 +1,7 @@
-module.exports = {
+module.exports = /** @type {const} */ ({
     parent: 'parent',
     parentProperty: 'parentProperty',
     path: 'path',
     pointer: 'pointer',
     value: 'value'
-};
+});

--- a/src/impl/index.js
+++ b/src/impl/index.js
@@ -7,6 +7,20 @@ const implV2 = require('./v2/index'),
 
 const REGEX__OPEN_API = /^3\./;
 
+/**
+ * @typedef {{
+ *     buildValidationMap: (pathsExamples: Array<string>) => Record<string, Set<string>>,
+ *     getJsonPathsToExamples: () => Array<string>,
+ *     prepare: (
+ *         openapiSpec: Object,
+ *         options?: {
+ *             noAdditionalProperties?: boolean,
+ *             allPropertiesRequired?: boolean
+ *         }
+ *     ) => object,
+ * }} Implementation
+ */
+
 module.exports = {
     getImplementation
 };
@@ -14,7 +28,7 @@ module.exports = {
 /**
  * Get the version-specific implementation for the OpenAPI-spec. Currently v2 and v3 are supported
  * @param {Object}  openapiSpec OpenAPI-spec
- * @returns {Object|null}
+ * @returns {Implementation | null}
  */
 function getImplementation(openapiSpec) {
     if (typeof openapiSpec.swagger === 'string') {

--- a/src/impl/service/common.js
+++ b/src/impl/service/common.js
@@ -117,6 +117,10 @@ function _excludeExamples(openApiSpec, paths, examplePaths) {
         });
 }
 
+/**
+ * @param {string} path
+ * @returns {boolean | undefined}
+ */
 function _isPropertiesDefinition(path) {
     // Path has to end with `properties`
     if (!path.match(/\['properties']$/)) { return; }
@@ -125,6 +129,10 @@ function _isPropertiesDefinition(path) {
     return !consecutiveMatch || consecutiveMatch.length % 2 !== 0;
 }
 
+/**
+ * @param {any} entity
+ * @returns {boolean}
+ */
 function _isObjectDefinition(entity) {
     return entity && (entity.type === 'object' || entity.properties);
 }

--- a/src/impl/service/common.js
+++ b/src/impl/service/common.js
@@ -33,8 +33,8 @@ module.exports = {
 /**
  * Apply the input rule to all models of type object in the input openApiSpec
  * @param {Object}                 openApiSpec           The to-be-modified schema
- * @param {Array.<String>}         [examplePaths]        The paths to the examples, which's content must not be modified
- * @param {JsonPathMatchCallbackBuilder}  [matchCallbackBuilder]  Function to build a callback
+ * @param {Array.<String>}         examplePaths          The paths to the examples, which's content must not be modified
+ * @param {JsonPathMatchCallbackBuilder}  matchCallbackBuilder    Function to build a callback
  *                                                                that will be called on each match
  */
 function applyCallbackToAllObjectModels(openApiSpec, examplePaths, matchCallbackBuilder) {

--- a/src/impl/service/common.js
+++ b/src/impl/service/common.js
@@ -58,10 +58,32 @@ function applyCallbackToAllObjectModels(openApiSpec, examplePaths, matchCallback
 }
 
 /**
+ * @overload
  * Find matching elements in JSON.
  * @param {Object}                  json                JSON to be searched
  * @param {String}                  path                JSON-path to search
- * @param {String}                  [resultType="path"] Result-type of the query
+ * @param {"path"}                  [resultType="path"] Result-type of the query
+ * @param {JsonPathMatchCallback}   [callback]          Function to be called on a match
+ * @returns {Array<string>} Result of the query, depending on the `resultType`
+ * @private
+ */
+
+/**
+ * @overload
+ * Find matching elements in JSON.
+ * @param {Object}                  json                JSON to be searched
+ * @param {String}                  path                JSON-path to search
+ * @param {"value"}                 resultType          Result-type of the query
+ * @param {JsonPathMatchCallback}   [callback]          Function to be called on a match
+ * @returns {any} Result of the query, depending on the `resultType`
+ * @private
+ */
+
+/**
+ * Find matching elements in JSON.
+ * @param {Object}                  json                JSON to be searched
+ * @param {String}                  path                JSON-path to search
+ * @param {"path" | "value"}        [resultType="path"] Result-type of the query
  * @param {JsonPathMatchCallback}   [callback]          Function to be called on a match
  * @returns {any} Result of the query, depending on the `resultType`
  * @private

--- a/src/impl/v2/index.js
+++ b/src/impl/v2/index.js
@@ -33,7 +33,7 @@ function getJsonPathsToExamples() { return [PATH__EXAMPLES]; }
  * The pointer of the schema is derived from the pointer to the example and doesn't necessarily mean
  * that the schema actually exists.
  * @param {Array.<String>}  pathsExamples   Paths to the examples
- * @returns {Object.<String, String>} Map with schema-pointers as key and example-pointers as value
+ * @returns {Record<String, Set<String>>} Map with schema-pointers as key and example-pointers as value
  * @private
  */
 function buildValidationMap(pathsExamples) {
@@ -42,7 +42,7 @@ function buildValidationMap(pathsExamples) {
         validationMap[pathSchema] = (validationMap[pathSchema] || new Set())
             .add(pathExample);
         return validationMap;
-    }, {});
+    }, /** @type {Record<String, Set<String>>} */ ({}));
 }
 
 /**

--- a/src/impl/v2/index.js
+++ b/src/impl/v2/index.js
@@ -49,8 +49,9 @@ function buildValidationMap(pathsExamples) {
  * Pre-processes the OpenAPI-spec, for further use.
  * The passed spec won't be modified. If a modification happens, a modified copy will be returned.
  * @param {Object}  openapiSpec                     The OpenAPI-spec as JSON-schema
- * @param {boolean} [noAdditionalProperties=false]  Don't allow properties that are not defined in the schema
- * @param {boolean} [allPropertiesRequired=false]   Make all properties required
+ * @param {Object}  [options]
+ * @param {boolean} [options.noAdditionalProperties=false] Don't allow properties that are not defined in the schema
+ * @param {boolean} [options.allPropertiesRequired=false] Make all properties required
  * @return {Object} The prepared OpenAPI-spec
  */
 function prepare(openapiSpec, { noAdditionalProperties, allPropertiesRequired } = {}) {

--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -25,10 +25,10 @@ const PATH__EXAMPLE = `${RESPONSES}${SINGLE_EXAMPLE}`,
     PROP__EXAMPLE = 'example',
     PROP__EXAMPLES = 'examples';
 
-const ExampleType = {
+const ExampleType = /** @type {const} */ ({
     single: 'single',
     multi: 'multi'
-};
+});
 
 // PUBLIC API
 
@@ -101,7 +101,7 @@ function prepare(openapiSpec, { noAdditionalProperties, allPropertiesRequired } 
  * It is assumed that the JSON-pointer to the example is valid and existing.
  * @param {String}  examplePointer JSON-pointer to example
  * @returns {{
- *     exampleType: ExampleType,
+ *     exampleType: typeof ExampleType[keyof typeof ExampleType],
  *     pathSchema: String
  * }} JSON-path to the corresponding response-schema
  * @private
@@ -109,7 +109,6 @@ function prepare(openapiSpec, { noAdditionalProperties, allPropertiesRequired } 
 function _getSchemaPointerOfExample(examplePointer) {
     const pathSegs = examplePointer.split('/'),
         idxExample = pathSegs.lastIndexOf(PROP__EXAMPLE),
-        /** @type ExampleType */
         exampleType = idxExample > -1
             ? ExampleType.single
             : ExampleType.multi,

--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -60,7 +60,7 @@ function getJsonPathsToExamples() {
  * The pointer of the schema is derived from the pointer to the example and doesn't necessarily mean
  * that the schema actually exists.
  * @param {Array.<String>}  pathsExamples   Paths to the examples
- * @returns {Object.<String, String>} Map with schema-pointers as key and example-pointers as value
+ * @returns {Record<String, Set<String>>} Map with schema-pointers as key and example-pointers as value
  * @private
  */
 function buildValidationMap(pathsExamples) {
@@ -76,7 +76,7 @@ function buildValidationMap(pathsExamples) {
         validationMap[pathSchema] = (validationMap[pathSchema] || new Set())
             .add(pathExample);
         return validationMap;
-    }, {});
+    }, /** @type {Record<String, Set<String>>} */ ({}));
 }
 
 /**

--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -83,8 +83,9 @@ function buildValidationMap(pathsExamples) {
  * Pre-processes the OpenAPI-spec, for further use.
  * The passed spec won't be modified. If a modification happens, a modified copy will be returned.
  * @param {Object}  openapiSpec     The OpenAPI-spec as JSON-schema
- * @param {boolean} [noAdditionalProperties=false]  Don't allow properties that are not defined in the schema
- * @param {boolean} [allPropertiesRequired=false]   Make all properties required
+ * @param {Object}  options
+ * @param {boolean} [options.noAdditionalProperties=false] Don't allow properties that are not defined in the schema
+ * @param {boolean} [options.allPropertiesRequired=false] Make all properties required
  * @return {Object} The prepared OpenAPI-spec
  */
 function prepare(openapiSpec, { noAdditionalProperties, allPropertiesRequired } = {}) {

--- a/src/impl/v3/index.js
+++ b/src/impl/v3/index.js
@@ -102,7 +102,7 @@ function prepare(openapiSpec, { noAdditionalProperties, allPropertiesRequired } 
  * @param {String}  examplePointer JSON-pointer to example
  * @returns {{
  *     exampleType: typeof ExampleType[keyof typeof ExampleType],
- *     pathSchema: String
+ *     pathSchemaAsArray: Array<String>
  * }} JSON-path to the corresponding response-schema
  * @private
  */

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ async function validateExamples(openapiSpec, { noAdditionalProperties, ignoreFor
     let pathsExamples = impl.getJsonPathsToExamples()
         .reduce((res, pathToExamples) => {
             return res.concat(_pathToPointer(pathToExamples, openapiSpec));
-        }, []);
+        }, /** @type {Array<string>} */ ([]));
     return _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFormats });
 }
 
@@ -208,7 +208,7 @@ async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
                 return response;
             }
             return _mergeValidationResponses(res, response);
-        }, null),
+        }, /** @type {ValidationResponse | null} */ (null)),
         { statistics: { matchingFilePathsMapping } }
     );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -549,7 +549,7 @@ function _initStatistics() {
  * Extract object by the given JSON-pointer
  * @param {String}      pointer JSON-pointer
  * @param {Object}      json JSON to extract the object(s) from
- * @returns {Object}    Extracted object
+ * @returns {Object | undefined} Extracted object
  */
 function _getByPointer(pointer, json) {
     try {
@@ -567,7 +567,7 @@ function _getByPointer(pointer, json) {
  * @param {Object}      options
  * @param {Function}    options.createValidator     Factory, to create JSON-schema validator
  * @param {Object}      options.schema              JSON-schema
- * @param {Object}      options.example             Example to validate
+ * @param {Object | undefined} options.example      Example to validate
  * @param {ValidationStatistics} options.statistics Object to contain statistics metrics
  * @param {String}      [options.filePathExample]   File-path to the example file
  * @returns {Array.<Object>} Array with errors. Empty array, if examples are valid

--- a/src/index.js
+++ b/src/index.js
@@ -566,7 +566,7 @@ function _getByPointer(pointer, json) {
  * itself
  * @param {Object}      options
  * @param {Function}    options.createValidator     Factory, to create JSON-schema validator
- * @param {Object}      options.schema              JSON-schema
+ * @param {Object | Object[] | null | undefined} options.schema JSON-schema
  * @param {Object | undefined} options.example      Example to validate
  * @param {ValidationStatistics} options.statistics Object to contain statistics metrics
  * @param {String}      [options.filePathExample]   File-path to the example file

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
  */
 
 /** @import Ajv from 'ajv-draft-04' */
+/** @import { CustomError } from './application-error' */
 
 const
     merge = require('lodash.merge'),

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ module.exports = {
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
- * @returns {ValidationResponse}
+ * @returns {Promise<ValidationResponse>}
  */
 async function validateExamples(openapiSpec, { noAdditionalProperties, ignoreFormats, allPropertiesRequired } = {}) {
     const impl = Determiner.getImplementation(openapiSpec);
@@ -123,7 +123,7 @@ async function validateExamples(openapiSpec, { noAdditionalProperties, ignoreFor
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
- * @returns {ValidationResponse}
+ * @returns {Promise<ValidationResponse>}
  */
 async function validateFile(filePath, { noAdditionalProperties, ignoreFormats, allPropertiesRequired } = {}) {
     let openapiSpec = null;
@@ -151,7 +151,7 @@ async function validateFile(filePath, { noAdditionalProperties, ignoreFormats, a
  *                                              "unsupported format" errors). If an Array with only one string is
  *                                              provided where the formats are separated with `\n`, the entries
  *                                              will be expanded to a new array containing all entries.
- * @returns {ValidationResponse}
+ * @returns {Promise<ValidationResponse>}
  */
 async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
     { cwdToMappingFile, noAdditionalProperties, ignoreFormats, allPropertiesRequired } = {}
@@ -221,7 +221,7 @@ async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
- * @returns {ValidationResponse}
+ * @returns {Promise<ValidationResponse>}
  */
 async function validateExample(filePathSchema, pathSchema, filePathExample, {
     noAdditionalProperties,
@@ -256,7 +256,7 @@ async function validateExample(filePathSchema, pathSchema, filePathExample, {
 /**
  * Parses the OpenAPI-spec (supports JSON and YAML)
  * @param {String}  filePath    File-path to the OpenAPI-spec
- * @returns {object}    Parsed OpenAPI-spec
+ * @returns {Promise<object>}   Parsed OpenAPI-spec
  * @private
  */
 async function _parseSpec(filePath) {

--- a/src/index.js
+++ b/src/index.js
@@ -574,8 +574,8 @@ function _getByPointer(pointer, json) {
  * @private
  */
 function _validateExample({ createValidator, schema, example, statistics, filePathExample }) {
-    const
-        errors = [];
+    /** @type {Array<Object>} */
+    const errors = [];
     statistics.examplesTotal++;
     // No schema, no validation (Examples without schema are considered valid)
     if (!schema) {

--- a/src/index.js
+++ b/src/index.js
@@ -604,6 +604,9 @@ function _validateExample({ createValidator, schema, example, statistics, filePa
 
 /**
  * Create a new instance of a JSON schema validator
+ * @param {Object} specSchema
+ * @param {Object} options
+ * @param {Array<string>} [options.ignoreFormats]
  * @returns {function(): Ajv}
  * @private
  */
@@ -639,6 +642,9 @@ function _extractSchema(schemaPointer, openapiSpec, suppressErrorIfNotFound = fa
     return schema;
 }
 
+/**
+ * @param {string} schemaPointer
+ */
 function _pathToSchemaNotFoundError(schemaPointer) {
     throw new ErrorJsonPathNotFound(`Path to schema can't be found: '${schemaPointer}'`, {
         params: {

--- a/src/index.js
+++ b/src/index.js
@@ -495,7 +495,7 @@ function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFo
  * @param {string}                  options.schemaPointer     JSON-pointer to schema (for request- or response-property)
  * @param {Record<String, Set<String>>} options.validationMap Map with schema-pointers as key and example-pointers as
  *                                                            value
- * @param {Object}                  options.statistics        Object to contain statistics metrics
+ * @param {ValidationStatistics}    options.statistics        Object to contain statistics metrics
  * @param {Object}                  options.validationResult  Container, for the validation-results
  * @private
  */
@@ -568,7 +568,7 @@ function _getByPointer(pointer, json) {
  * @param {Function}    options.createValidator     Factory, to create JSON-schema validator
  * @param {Object}      options.schema              JSON-schema
  * @param {Object}      options.example             Example to validate
- * @param {Object}      options.statistics          Object to contain statistics metrics
+ * @param {ValidationStatistics} options.statistics Object to contain statistics metrics
  * @param {String}      [options.filePathExample]   File-path to the example file
  * @returns {Array.<Object>} Array with errors. Empty array, if examples are valid
  * @private

--- a/src/index.js
+++ b/src/index.js
@@ -93,9 +93,10 @@ module.exports = {
 /**
  * Validates OpenAPI-spec with embedded examples.
  * @param {Object}  openapiSpec OpenAPI-spec
- * @param {boolean} [noAdditionalProperties=false]  Don't allow properties that are not defined in the schema
- * @param {boolean} [allPropertiesRequired=false]   Make all properties required
- * @param {Array.<string>} [ignoreFormats]          List of datatype formats that shall be ignored (to prevent
+ * @param {Object} [options]
+ * @param {boolean} [options.noAdditionalProperties=false] Don't allow properties that are not defined in the schema
+ * @param {boolean} [options.allPropertiesRequired=false] Make all properties required
+ * @param {Array.<string>} [options.ignoreFormats]  List of datatype formats that shall be ignored (to prevent
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
@@ -115,9 +116,10 @@ async function validateExamples(openapiSpec, { noAdditionalProperties, ignoreFor
 /**
  * Validates OpenAPI-spec with embedded examples.
  * @param {string}  filePath                        File-path to the OpenAPI-spec
- * @param {boolean} [noAdditionalProperties=false]  Don't allow properties that are not defined in the schema
- * @param {boolean} [allPropertiesRequired=false]   Make all properties required
- * @param {Array.<string>} [ignoreFormats]          List of datatype formats that shall be ignored (to prevent
+ * @param {Object}  [options]
+ * @param {boolean} [options.noAdditionalProperties=false] Don't allow properties that are not defined in the schema
+ * @param {boolean} [options.allPropertiesRequired=false] Make all properties required
+ * @param {Array.<string>} [options.ignoreFormats]  List of datatype formats that shall be ignored (to prevent
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
@@ -139,11 +141,13 @@ async function validateFile(filePath, { noAdditionalProperties, ignoreFormats, a
  * @param {string}  globMapExternalExamples     File-path (globs are supported) to the mapping-file containing JSON-
  *                                              paths to schemas as key and a single file-path or Array of file-paths
  *                                              to external examples
- * @param {boolean} [cwdToMappingFile=false]    Change working directory for resolving the example-paths (relative to
+ * @param {Object}  [options]
+ * @param {boolean} [options.cwdToMappingFile=false]
+ *                                              Change working directory for resolving the example-paths (relative to
  *                                              the mapping-file)
- * @param {boolean} [noAdditionalProperties=false] Don't allow properties that are not defined in the schema
- * @param {boolean} [allPropertiesRequired=false]  Make all properties required
- * @param {Array.<string>} [ignoreFormats]      List of datatype formats that shall be ignored (to prevent
+ * @param {boolean} [options.noAdditionalProperties=false] Don't allow properties that are not defined in the schema
+ * @param {boolean} [options.allPropertiesRequired=false] Make all properties required
+ * @param {Array.<string>} [options.ignoreFormats] List of datatype formats that shall be ignored (to prevent
  *                                              "unsupported format" errors). If an Array with only one string is
  *                                              provided where the formats are separated with `\n`, the entries
  *                                              will be expanded to a new array containing all entries.
@@ -210,9 +214,10 @@ async function validateExamplesByMap(filePathSchema, globMapExternalExamples,
  * @param {String}  filePathSchema                  File-path to the OpenAPI-spec
  * @param {String}  pathSchema                      JSON-path to the schema
  * @param {String}  filePathExample                 File-path to the external example-file
- * @param {boolean} [noAdditionalProperties=false]  Don't allow properties that are not described in the schema
- * @param {boolean} [allPropertiesRequired=false]   Make all properties required
- * @param {Array.<string>} [ignoreFormats]          List of datatype formats that shall be ignored (to prevent
+ * @param {Object}  [options]
+ * @param {boolean} [options.noAdditionalProperties=false] Don't allow properties that are not described in the schema
+ * @param {boolean} [options.allPropertiesRequired=false] Make all properties required
+ * @param {Array.<string>} [options.ignoreFormats]  List of datatype formats that shall be ignored (to prevent
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
@@ -305,10 +310,11 @@ function _validate(validationHandler) {
  *                                                                  key and a single file-path or Array of file-paths
  *                                                                  to external examples
  * @param {ValidationStatistics}    statistics                      Validation-statistics
- * @param {boolean}                 [cwdToMappingFile=false]        Change working directory for resolving the example-
+ * @param {Object}                  options
+ * @param {boolean}                 [options.cwdToMappingFile=false] Change working directory for resolving the example-
  *                                                                  paths (relative to the mapping-file)
- * @param {string}                  [dirPathMapExternalExamples]    The directory-path of the mapping-file
- * @param {Array.<string>} [ignoreFormats]          List of datatype formats that shall be ignored (to prevent
+ * @param {string}                  [options.dirPathMapExternalExamples] The directory-path of the mapping-file
+ * @param {Array.<string>} [options.ignoreFormats]  List of datatype formats that shall be ignored (to prevent
  *                                                  "unsupported format" errors). If an Array with only one string is
  *                                                  provided where the formats are separated with `\n`, the entries
  *                                                  will be expanded to a new array containing all entries.
@@ -437,7 +443,8 @@ function _getSchmaPointer(pathSchema, openapiSpec) {
  * @param {Object}          impl            Spec-dependant validator
  * @param {Array.<String>}  pathsExamples   JSON-paths to examples
  * @param {Object}          openapiSpec     OpenAPI-spec
- * @param {Array.<string>} [ignoreFormats]  List of datatype formats that shall be ignored (to prevent
+ * @param {Object}          options
+ * @param {Array.<string>} [options.ignoreFormats] List of datatype formats that shall be ignored (to prevent
  *                                          "unsupported format" errors). If an Array with only one string is
  *                                          provided where the formats are separated with `\n`, the entries
  *                                          will be expanded to a new array containing all entries.
@@ -479,12 +486,13 @@ function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFo
 
 /**
  * Validates a single schema.
- * @param {Object}                  openapiSpec         OpenAPI-spec
- * @param {ajv}                     createValidator     Factory, to create JSON-schema validator
- * @param {string}                  schemaPointer          JSON-pointer to schema (for request- or response-property)
- * @param {Object.<String, String>} validationMap Map with schema-pointers as key and example-pointers as value
- * @param {Object}                  statistics          Object to contain statistics metrics
- * @param {Object}                  validationResult    Container, for the validation-results
+ * @param {Object}                  options
+ * @param {Object}                  options.openapiSpec       OpenAPI-spec
+ * @param {ajv}                     options.createValidator   Factory, to create JSON-schema validator
+ * @param {string}                  options.schemaPointer     JSON-pointer to schema (for request- or response-property)
+ * @param {Object.<String, String>} options.validationMap Map with schema-pointers as key and example-pointers as value
+ * @param {Object}                  options.statistics        Object to contain statistics metrics
+ * @param {Object}                  options.validationResult  Container, for the validation-results
  * @private
  */
 function _validateSchema({
@@ -552,11 +560,12 @@ function _getByPointer(pointer, json) {
  * given path.
  * `pathExample` and `filePathExample` are exclusively mandatory.
  * itself
- * @param {Function}    createValidator     Factory, to create JSON-schema validator
- * @param {Object}      schema              JSON-schema
- * @param {Object}      example             Example to validate
- * @param {Object}      statistics          Object to contain statistics metrics
- * @param {String}      [filePathExample]   File-path to the example file
+ * @param {Object}      options
+ * @param {Function}    options.createValidator     Factory, to create JSON-schema validator
+ * @param {Object}      options.schema              JSON-schema
+ * @param {Object}      options.example             Example to validate
+ * @param {Object}      options.statistics          Object to contain statistics metrics
+ * @param {String}      [options.filePathExample]   File-path to the example file
  * @returns {Array.<Object>} Array with errors. Empty array, if examples are valid
  * @private
  */

--- a/src/index.js
+++ b/src/index.js
@@ -493,7 +493,8 @@ function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFo
  * @param {Object}                  options.openapiSpec       OpenAPI-spec
  * @param {function(): Ajv}         options.createValidator   Factory, to create JSON-schema validator
  * @param {string}                  options.schemaPointer     JSON-pointer to schema (for request- or response-property)
- * @param {Object.<String, String>} options.validationMap Map with schema-pointers as key and example-pointers as value
+ * @param {Record<String, Set<String>>} options.validationMap Map with schema-pointers as key and example-pointers as
+ *                                                            value
  * @param {Object}                  options.statistics        Object to contain statistics metrics
  * @param {Object}                  options.validationResult  Container, for the validation-results
  * @private

--- a/src/index.js
+++ b/src/index.js
@@ -455,13 +455,14 @@ function _getSchmaPointer(pathSchema, openapiSpec) {
  * @private
  */
 function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFormats }) {
-    const statistics = _initStatistics(),
-        validationResult = {
-            valid: true,
-            statistics,
-            errors: []
-        },
-        createValidator = _initValidatorFactory(openapiSpec, { ignoreFormats });
+    const statistics = _initStatistics();
+    /** @type {ValidationResponse} */
+    const validationResult = {
+        valid: true,
+        statistics,
+        errors: []
+    };
+    const createValidator = _initValidatorFactory(openapiSpec, { ignoreFormats });
     let validationMap;
     try {
         // Create mapping between JSON-schemas and examples
@@ -496,7 +497,7 @@ function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFo
  * @param {Record<String, Set<String>>} options.validationMap Map with schema-pointers as key and example-pointers as
  *                                                            value
  * @param {ValidationStatistics}    options.statistics        Object to contain statistics metrics
- * @param {Object}                  options.validationResult  Container, for the validation-results
+ * @param {ValidationResponse}      options.validationResult  Container, for the validation-results
  * @private
  */
 function _validateSchema({

--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,9 @@ module.exports = {
 /**
  * ValidationStatistics
  * @typedef {{
+ *      [SYM__INTERNAL]: {
+ *          [PROP__SCHEMAS_WITH_EXAMPLES]: Set<Object>
+ *      },
  *      schemasWithExamples: number,
  *      examplesTotal: number,
  *      examplesWithoutSchema: number,
@@ -539,12 +542,11 @@ function _initStatistics() {
             [PROP__SCHEMAS_WITH_EXAMPLES]: new Set()
         },
         examplesTotal: 0,
-        examplesWithoutSchema: 0
+        examplesWithoutSchema: 0,
+        get [PROP__SCHEMAS_WITH_EXAMPLES]() {
+            return statistics[SYM__INTERNAL][PROP__SCHEMAS_WITH_EXAMPLES].size;
+        }
     };
-    Object.defineProperty(statistics, PROP__SCHEMAS_WITH_EXAMPLES, {
-        enumerable: true,
-        get: () => statistics[SYM__INTERNAL][PROP__SCHEMAS_WITH_EXAMPLES].size
-    });
     return statistics;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
  * Entry-point for the validator-API
  */
 
+/** @import Ajv from 'ajv-draft-04' */
+
 const
     merge = require('lodash.merge'),
     flatten = require('lodash.flatten'),
@@ -488,7 +490,7 @@ function _validateExamplesPaths({ impl }, pathsExamples, openapiSpec, { ignoreFo
  * Validates a single schema.
  * @param {Object}                  options
  * @param {Object}                  options.openapiSpec       OpenAPI-spec
- * @param {ajv}                     options.createValidator   Factory, to create JSON-schema validator
+ * @param {function(): Ajv}         options.createValidator   Factory, to create JSON-schema validator
  * @param {string}                  options.schemaPointer     JSON-pointer to schema (for request- or response-property)
  * @param {Object.<String, String>} options.validationMap Map with schema-pointers as key and example-pointers as value
  * @param {Object}                  options.statistics        Object to contain statistics metrics
@@ -595,7 +597,7 @@ function _validateExample({ createValidator, schema, example, statistics, filePa
 
 /**
  * Create a new instance of a JSON schema validator
- * @returns {ajv}
+ * @returns {function(): Ajv}
  * @private
  */
 function _initValidatorFactory(specSchema, { ignoreFormats }) {
@@ -607,7 +609,7 @@ function _initValidatorFactory(specSchema, { ignoreFormats }) {
         formats: ignoreFormats && ignoreFormats.reduce((result, entry) => {
             result[entry] = () => true;
             return result;
-        }, {})
+        }, /** @type {Record<string, () => boolean>} */ ({}))
     });
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -418,7 +418,7 @@ function _pathToPointer(path, openapiSpec) {
 }
 /**
  * Extract JSON-pointer(s) for specific path from a OpenAPI-spec
- * @param {String}  path  JSON-path in the OpenAPI-Spec
+ * @param {String}  pathSchema  JSON-path in the OpenAPI-Spec
  * @param {Object}  openapiSpec         OpenAPI-spec
  * @returns {String} JSON-pointer to schema or throws error
  * @private

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 
 /** @import Ajv from 'ajv-draft-04' */
 /** @import { CustomError } from './application-error' */
+/** @import { Implementation } from './impl' */
 
 const
     merge = require('lodash.merge'),
@@ -443,7 +444,8 @@ function _getSchmaPointer(pathSchema, openapiSpec) {
 
 /**
  * Validates examples at the given paths in the OpenAPI-spec.
- * @param {Object}          impl            Spec-dependant validator
+ * @param {Object}          impl
+ * @param {Implementation}  impl.impl       Spec-dependant validator
  * @param {Array.<String>}  pathsExamples   JSON-paths to examples
  * @param {Object}          openapiSpec     OpenAPI-spec
  * @param {Object}          options

--- a/src/index.js
+++ b/src/index.js
@@ -56,12 +56,11 @@ const ErrorJsonPathNotFound = createError(ErrorType.jsonPathNotFound);
 
 // PUBLIC API
 
-module.exports = {
-    'default': validateExamples,
-    validateFile,
-    validateExample,
-    validateExamplesByMap
-};
+exports.default = validateExamples;
+exports.validateExamples = validateExamples;
+exports.validateFile = validateFile;
+exports.validateExample = validateExample;
+exports.validateExamplesByMap = validateExamplesByMap;
 
 // IMPLEMENTATION DETAILS
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,8 @@ const SYM__INTERNAL = Symbol('internal'),
  * ErrorJsonPathNotFound
  * @typedef {{
  *      cause: {
- *          [params]: {
- *              [path]: string
+ *          params?: {
+ *              path?: string
  *          }
  *      }
  * }} ErrorJsonPathNotFound
@@ -69,7 +69,7 @@ module.exports = {
  *      schemasWithExamples: number,
  *      examplesTotal: number,
  *      examplesWithoutSchema: number,
- *      [matchingFilePathsMapping]: number
+ *      matchingFilePathsMapping?: number
  * }} ValidationStatistics
  */
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,6 @@
+/** @import { ApplicationError } from "../application-error" */
+/** @import { ValidationResponse, ValidationStatistics } from ".." */
+
 const path = require('path'),
     refParser = require('@apidevtools/json-schema-ref-parser');
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -8,8 +8,9 @@ module.exports = {
 
 /**
  * Creates a unified response for the validation-result
- * @param {Array.<ApplicationError>}    errors
- * @param {ValidationStatistics}        statistics
+ * @param {Object}                      options
+ * @param {Array.<ApplicationError>}    options.errors
+ * @param {ValidationStatistics}        [options.statistics]
  * @returns {ValidationResponse}
  * @private
  */

--- a/src/validator.js
+++ b/src/validator.js
@@ -2,10 +2,12 @@
  * Wrapper for the JSONSchema-validator
  */
 
+/** @import * as ajv from 'ajv-draft-04' */
+
 const { JSONPath: jsonPath } = require('jsonpath-plus'),
     JsonPointer = require('json-pointer'),
-    Ajv = require('ajv-draft-04'),
-    addFormats = require('ajv-formats');
+    { default: Ajv } = require('ajv-draft-04'),
+    { default: addFormats } = require('ajv-formats');
 
 const PROP__ID = '$id',
     JSON_PATH__REFS = '$..\$ref',
@@ -20,8 +22,8 @@ module.exports = {
 /**
  * Get a factory-function to create a prepared validator-instance
  * @param {Object}  specSchema  OpenAPI-spec of which potential local references will be extracted
- * @param {Object}  [options]   Options for the validator
- * @returns {function(): (ajv | ajv.Ajv)}
+ * @param {ajv.Options} [options] Options for the validator
+ * @returns {function(): Ajv}
  */
 function getValidatorFactory(specSchema, options) {
     const preparedSpecSchema = _createReferenceSchema(specSchema);
@@ -37,7 +39,7 @@ function getValidatorFactory(specSchema, options) {
 
 /**
  * Compiles the validator-function.
- * @param {ajv | ajv.Ajv}   validator       Validator-instance
+ * @param {Ajv}             validator       Validator-instance
  * @param {Object}          responseSchema  The response-schema, against the examples will be validated
  * @returns {ajv.ValidateFunction}
  */

--- a/src/validator.js
+++ b/src/validator.js
@@ -65,9 +65,7 @@ function compileValidate(validator, responseSchema) {
  * @private
  */
 function _prepareResponseSchema(specSchema, idSchema) {
-    const preparedSchema = Object.assign({}, specSchema);
-    preparedSchema[PROP__ID] = idSchema;
-    return preparedSchema;
+    return { ...specSchema, [PROP__ID]: idSchema };
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "module": "nodenext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js"]
+}

--- a/webpack/config.babel.js
+++ b/webpack/config.babel.js
@@ -24,7 +24,7 @@ const BASE_CONFIG = {
         path: path.resolve(PROJECT_ROOT, 'dist'),
         filename: '[name].js',
         chunkFilename: '[name].js',
-        libraryTarget: 'commonjs2'
+        libraryTarget: 'commonjs-static'
     },
     plugins: [
         new ESLintPlugin({


### PR DESCRIPTION
Our JSDoc type annotations have a number of mistakes, but with a few easy tweaks they can be made useful enough for downstream TypeScript consumers to interact with the library.

There are still 39 TypeScript errors that you can see using `npx tsc --checkJs`. Ideally in the future, we should fix them and enable this check by default.