### PR TITLE
test: add Xquik search response example

### DIFF
--- a/test/data/v3/xquik-search-response-example.json
+++ b/test/data/v3/xquik-search-response-example.json
@@ -1,0 +1,160 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik API",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "operationId": "searchTweets",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 200
+            }
+          }
+        ],
+        "security": [
+          {
+            "apiKey": []
+          },
+          {
+            "oauthBearer": []
+          },
+          {}
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedTweets"
+                },
+                "example": {
+                  "tweets": [
+                    {
+                      "id": "1234567890",
+                      "text": "Just launched our new feature!",
+                      "createdAt": "2025-01-15T12:00:00Z",
+                      "likeCount": 42,
+                      "retweetCount": 5,
+                      "replyCount": 3,
+                      "quoteCount": 1,
+                      "viewCount": 1500,
+                      "bookmarkCount": 2,
+                      "author": {
+                        "id": "9876543210",
+                        "username": "xquikcom",
+                        "name": "Xquik",
+                        "verified": true
+                      }
+                    }
+                  ],
+                  "has_next_page": true,
+                  "next_cursor": "DAACCgACGRElMJcAAA"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
+      "oauthBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "PaginatedTweets": {
+        "type": "object",
+        "required": [
+          "tweets",
+          "has_next_page",
+          "next_cursor"
+        ],
+        "properties": {
+          "tweets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchTweet"
+            }
+          },
+          "has_next_page": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "SearchTweet": {
+        "type": "object",
+        "required": [
+          "id",
+          "text"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "likeCount": {
+            "type": "integer"
+          },
+          "retweetCount": {
+            "type": "integer"
+          },
+          "replyCount": {
+            "type": "integer"
+          },
+          "quoteCount": {
+            "type": "integer"
+          },
+          "viewCount": {
+            "type": "integer"
+          },
+          "bookmarkCount": {
+            "type": "integer"
+          },
+          "author": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/specs/impl/v3/index.js
+++ b/test/specs/impl/v3/index.js
@@ -29,6 +29,7 @@ const JSON_PATH__CONTEXT_MUTUALLY_EXCLUSIVE = '/paths/~1pets/get/responses/200/c
     REL_PATH__EXAMPLE_AND_EXAMPLES__SIMPLE = 'v3/simple-api-with-example-and-examples',
     REL_PATH__EXAMPLE_AND_EXAMPLES__MIME_COMPLEX = 'v3/simple-api-with-example-and-examples-mime-complex-invalid',
     REL_PATH__EXAMPLES__SIMPLE = 'v3/simple-api-with-examples',
+    REL_PATH__XQUIK_SEARCH_RESPONSE = 'v3/xquik-search-response-example',
     REL_PATH__WITH_INTERNAL_REFS = 'v3/simple-api-with-examples-with-refs',
     REL_PATH__EXAMPLES__INVALID__WITH_INTERNAL_REFS = 'v3/simple-api-with-examples-with-refs-invalid',
     FILE_PATH__EXAMPLE__WITH_ADDITIONAL_PROPERTIES__LIST
@@ -89,6 +90,9 @@ describe('Main-module, for v3 should', function() {
         describe('`example`-property', function() {
             it('valid single example', async function() {
                 (await validateExamples(loadTestData(REL_PATH__EXAMPLE__SIMPLE))).valid.should.equal(true);
+            });
+            it('valid Xquik search response example', async function() {
+                (await validateExamples(loadTestData(REL_PATH__XQUIK_SEARCH_RESPONSE))).valid.should.equal(true);
             });
             it('invalid example with internal refs', async function() {
                 (await validateExamples(loadTestData(REL_PATH__EXAMPLE__INVALID__WITH_INTERNAL_REFS)))


### PR DESCRIPTION
## Summary
- Add a compact OpenAPI 3.1 response example fixture for Xquik's public tweet search operation.
- Cover the fixture in the existing v3 `example` validation path.

## Validation
- `npm ci`
- `npm run build`
- `npx mocha --require "./test/util/setup-tests" "test/specs/impl/v3/index.js"`
- `npx eslint test/specs/impl/v3/index.js`
- `node -e "JSON.parse(require('fs').readFileSync('test/data/v3/xquik-search-response-example.json','utf8'))"`
- `git diff --check`
